### PR TITLE
LUGG-1097 Disable linkchecker auto updater

### DIFF
--- a/luggage_seo.strongarm.inc
+++ b/luggage_seo.strongarm.inc
@@ -14,7 +14,6 @@ function luggage_seo_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'linkchecker_action_status_code_301';
-  $strongarm->value = '10';
   $export['linkchecker_action_status_code_301'] = $strongarm;
 
   $strongarm = new stdClass();


### PR DESCRIPTION
To test:
- Pull down this branch on a local copy of luggage
- Run `drush fra -y; drush cc all`
- Go to `admin/config/content/linkchecker` and verify that the `Update permanently moved links` setting under the `Error Reporting` header is disabled.