### PR TITLE
LUGG-1098 Disable title attribute enforcement for links

### DIFF
--- a/luggage_seo.info
+++ b/luggage_seo.info
@@ -66,6 +66,7 @@ features[variable][] = linkchecker_scan_node_project
 features[variable][] = linkchecker_scan_node_resource
 features[variable][] = read_more_require_body_field
 features[variable][] = seo_checker_page
+features[variable][] = seo_threshold_title_attributes
 features[variable][] = site_map_page_title
 features[variable][] = site_map_show_count
 features[variable][] = site_map_show_description

--- a/luggage_seo.strongarm.inc
+++ b/luggage_seo.strongarm.inc
@@ -153,6 +153,13 @@ function luggage_seo_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
+  $strongarm->name = 'seo_threshold_title_attributes';
+  $strongarm->value = '0';
+  $export['seo_threshold_title_attributes'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
   $strongarm->name = 'site_map_page_title';
   $strongarm->value = 'Site Map';
   $export['site_map_page_title'] = $strongarm;


### PR DESCRIPTION
To test:
- Pull down this branch on a local copy of luggage
- Run `drush fra -y; drush cc all`
- Go to `admin/config/content/seo_checker` and verify that the `Title attributes in <a href> - tags:` setting under the `THRESHOLDS FOR THE SEO RULES` header is set to 0.